### PR TITLE
remove port to connect to repository.snappydata.io

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ allprojects {
     mavenCentral()
     maven { url "https://oss.sonatype.org/content/groups/public" }
     maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
-    maven { url "http://repository.snappydata.io:8089/repository/internal" }
-    maven { url "http://repository.snappydata.io:8089/repository/snapshots" }
+    maven { url "http://repository.snappydata.io/repository/internal" }
+    maven { url "http://repository.snappydata.io/repository/snapshots" }
     maven { url "http://mvnrepository.com/artifact" }
     maven { url 'https://clojars.org/repo' }
   }


### PR DESCRIPTION

Fix the following error:  

> Connect to repository.snappydata.io:8089 [repository.snappydata.io/52.34.95.228] failed: Operation timed out